### PR TITLE
Specify how to notify people who will be on duty

### DIFF
--- a/reports.md
+++ b/reports.md
@@ -36,9 +36,8 @@ In order to achieve a fast response time to received reports, we implement a
 week long on-call duty that is rotated between members of the Code of Conduct
 Committee. Every week we assign one member to be the primary person on duty,
 and another member to be a secondary supporter. On-call duty ends and finishes
-every Monday at noon UTC, when a reminder is sent to conduct@djangoproject.com
-with information who is the next primary and secondary member on-duty following
-week. The schedule is managed via a [spreadsheet]. If a member won't be
+every Monday at noon UTC; the outgoing people-on-duty should notify the incoming
+ones on Slack.  The schedule is managed via a [spreadsheet]. If a member won't be
 available on given week, they should exchange their week with another member.
 
 ![spreadsheet](https://docs.google.com/a/sitarska.com/uc?authuser=0&id=0B_sMcBckSgWqX1p5cm50UmQ1VVk)


### PR DESCRIPTION
The text says that each Monday at noon UTC "a reminder is sent to
conduct@djangoproject.com with information who is the next primary and
secondary member on-duty following week", but does not specify who sends
that message, and as far as I can tell this isn't working. Instead, I
think it will work if the persons whose duty ends simply notify on Slack
the ones whose duty begins. New members of the committee will easily
pick up the habit and the trivial discussion will keep the channel
warmed up.