### PR TITLE
Added new members

### DIFF
--- a/membership.md
+++ b/membership.md
@@ -17,10 +17,19 @@ number is still too low, a call for volunteers is published on Django blog.
 
 ### Current members of the committee:
 
+- Brian Moloney, Co-Chair
+- Jeff Triplett, Co-Chair
+- Erik Romijn, Vice Chair
+- Mike Barkas
+- Olumide Bakare
 - Amber Brown (Hawkowl)
-- Jeff Triplett
-- Brian Moloney
+- Joseph V. Cardenas
+- Antonis Christofides
+- Michael Clark
+- Rebecca Conley
 - Lacey Williams Henschel
+- Tibbs Hefflin
+- Anna Makarudze
 - Frank Wiles (DSF board observer)
 
 ### Past members of the committee:
@@ -35,7 +44,7 @@ number is still too low, a call for volunteers is published on Django blog.
 
 Starting on 25th May, 2016, committee decided to introduce fixed-term
 membership. Each member of the committee is only obligated to serve on the
-committee for a fixed period of time, with 6 months being a default term. The
+committee for a fixed period of time, with 6-9 months being a default term. The
 idea behind it allows members of the committee to step down from serving
 without feeling guilty, and assumes an opt-in membership instead of opt-out, as
 it was thus far.
@@ -45,6 +54,16 @@ it was thus far.
 | Amber Brown (HawkOwl)   | January 5th 2015  | 6 months       | May 25th 2017      |
 | Jeff Triplett           | May 5th 2016      | 6 months       | May 25th 2017      |
 | Lacey Williams Henschel | January 19th 2017 | 6 months       | May 25th 2017      |
+| Rebecca Conley          | February 1, 2017  | 6 months       | July 31st 2017     |
+| Brian Moloney           | February 1, 2017  | 9 months       | October 31st 2017  |
+| Erik Romijn             | February 1, 2017  | 9 months       | October 31st 2017  |
+| Mike Barkas             | February 1, 2017  | 9 months       | October 31st 2017  |
+| Olumide Bakare          | February 1, 2017  | 9 months       | October 31st 2017  |
+| Joseph V. Cardenas      | February 1, 2017  | 9 months       | October 31st 2017  |
+| Antonis Christofides    | February 1, 2017  | 9 months       | October 31st 2017  |
+| Michael Clark           | February 1, 2017  | 9 months       | October 31st 2017  |
+| Tibbs Hefflin           | February 1, 2017  | 9 months       | October 31st 2017  |
+| Anna Makarudze          | February 1, 2017  | 9 months       | October 31st 2017  |
 
 After the membership term ends, the invitation to stay in the committee is
 automatically extended, but member has to confirm they're indeed still


### PR DESCRIPTION
Added new members.  Identified chairs, sorted alpha, added term lengths.  Updated default term to 6-9 months to be consistent with current term lengths.

Fixes #32